### PR TITLE
docs: ADR 0005 competency mastery storage, without history

### DIFF
--- a/docs/openedx_learning/decisions/0002-competency-criteria-model.rst
+++ b/docs/openedx_learning/decisions/0002-competency-criteria-model.rst
@@ -241,13 +241,10 @@ Decision
    4. ``CompetencyCriteria(oel_tagging_objecttag_id)``
    5. ``CompetencyCriteria(competency_criteria_group_id)``
    6. ``StudentCompetencyCriteriaStatus(user_id, competency_criteria_id)`` (unique)
-   7. ``StudentCompetencyCriteriaStatusHistory(user_id, competency_criteria_id, status_id)`` (unique -- at most one HISTORY row per learner, leaf, and status level, which also serves as the idempotency key for the append in :ref:`openedx-learning-adr-0004`)
-   8. ``StudentCompetencyCriteriaGroupStatus(user_id, competency_criteria_group_id)`` (unique)
-   9. ``StudentCompetencyCriteriaGroupStatusHistory(user_id, competency_criteria_group_id)``
-   10. ``StudentCompetencyStatus(user_id, oel_tagging_tag_id)`` (unique)
-   11. ``StudentCompetencyStatusHistory(user_id, oel_tagging_tag_id)``
-   12. ``CompetencyRuleProfile(scope_code)`` (unique -- at most one profile per distinct scope value; a plain unique constraint on the three raw nullable scope columns would not enforce this, since SQL never treats two ``NULL`` values as equal and this project's MySQL backend does not support the conditional/partial unique indexes that would otherwise route around that; see the ``scope_code`` column in Decision 3)
-   13. ``CompetencyMasteryStatuses(status)`` (unique)
+   7. ``StudentCompetencyCriteriaGroupStatus(user_id, competency_criteria_group_id)`` (unique)
+   8. ``StudentCompetencyStatus(user_id, oel_tagging_tag_id)`` (unique)
+   9. ``CompetencyRuleProfile(scope_code)`` (unique -- at most one profile per distinct scope value; a plain unique constraint on the three raw nullable scope columns would not enforce this, since SQL never treats two ``NULL`` values as equal and this project's MySQL backend does not support the conditional/partial unique indexes that would otherwise route around that; see the ``scope_code`` column in Decision 3)
+   10. ``CompetencyMasteryStatuses(status)`` (unique)
 
 6. Learner progress status concepts (``StudentCompetency*Status`` database tables)
 
@@ -259,12 +256,6 @@ Decision
    - ``StudentCompetencyCriteriaGroupStatus`` tracks status at ``CompetencyCriteriaGroup`` node level.
    - ``StudentCompetencyStatus`` tracks top-level competency demonstration state.
    - All learner status rows use a shared lookup table (``CompetencyMasteryStatuses``) so status semantics live in one place and student status tables stay structurally consistent.
-
-   Append-only history tables:
-
-   - ``StudentCompetencyCriteriaStatusHistory``
-   - ``StudentCompetencyCriteriaGroupStatusHistory``
-   - ``StudentCompetencyStatusHistory``
 
    Intended update flow (bottom-up materialization):
 
@@ -437,9 +428,5 @@ Changelog
 
 2026-07-27:
 
-* Split learner status storage into paired ACTIVE and HISTORY tables: added the append-only
-  ``StudentCompetencyCriteriaStatusHistory``, ``StudentCompetencyCriteriaGroupStatusHistory``,
-  and ``StudentCompetencyStatusHistory`` tables and their indexes alongside the in-place ACTIVE
-  tables, per :ref:`openedx-learning-adr-0005`.
-* Made the leaf HISTORY (``StudentCompetencyCriteriaStatusHistory``) index unique on ``(user_id, competency_criteria_id, status_id)``, the
-  idempotency key for the HISTORY append in :ref:`openedx-learning-adr-0004`.
+* Made the learner status indexes unique, so there is one row per learner and node. This is what
+  the in-place, monotone status updates in :ref:`openedx-learning-adr-0004` read, lock, and update.

--- a/docs/openedx_learning/decisions/0002-competency-criteria-model.rst
+++ b/docs/openedx_learning/decisions/0002-competency-criteria-model.rst
@@ -135,7 +135,7 @@ Decision
    7. ``rule_payload``: JSON payload keyed by ``rule_type`` to avoid freeform strings. It is structured JSON (not arbitrary freeform data): each ``rule_type`` defines the allowed payload shape and required keys, and validation enforces this contract. JSON is used instead of fixed columns like ``op``, ``value``, and ``scale`` so that future rule types (for example, ``MasteryLevel`` thresholds or plugin-defined evaluators such as CEL-based rules) can add their own fields without repeated schema migrations or many nullable columns. Examples:
 
       1. ``Grade``: ``{"op": "gte", "value": 0.75, "scale": "percent"}``. Allowed ``op`` values: ``gte``, ``lte``, ``eq``. ``value`` must be a fraction between 0.0 and 1.0 inclusive, matching the platform's existing fractional grade representation, not a 0-100 scale.
-   8. ``archived``: Boolean, defaults to false. Set instead of deleting a profile that is no longer wanted. Archived profiles are hidden from authoring and new associations but remain queryable, so existing ``CompetencyCriterion`` rows and learner status history stay resolvable.
+   8. ``archived``: Boolean, defaults to false. Set instead of deleting a profile that is no longer wanted. Archived profiles are hidden from authoring and new associations but remain queryable, so existing ``CompetencyCriterion`` rows and learner status rows stay resolvable.
 
    A check constraint requires that at most one of ``organization_id``, ``course_id``, and ``competency_taxonomy_id`` is non-null on any row, matching the scoping rule above.
 
@@ -268,6 +268,7 @@ Decision
 
       1. ``id``: unique primary key
       2. ``status``: unique status value (seeded values: “Demonstrated”, “AttemptedNotDemonstrated”, and “PartiallyAttempted”)
+      3. ``rank``: unique small integer ordering the statuses from lowest to highest: “AttemptedNotDemonstrated”, “PartiallyAttempted”, “Demonstrated”. ``id`` does not carry that order and must not be used for it. This column is what lets the monotone merge in ADR 0004 Decision 2 compare the stored status against the newly computed one in a single ``UPDATE``, rather than reading the row into Python and writing it back under a lock the design does not otherwise need.
 
       Notes:
 
@@ -279,7 +280,8 @@ Decision
       2. ``competency_criteria_id``: Foreign key to ``CompetencyCriterion.id``
       3. ``user_id``: Foreign key pointing to user_id (presumably the learner's id, although it appears that it is possible for staff to get grades as well) in ``auth_user`` table
       4. ``status_id``: Foreign key to ``CompetencyMasteryStatuses.id``
-      5. ``created``: The timestamp at which the student's criterion status was set.
+      5. ``created``: The timestamp at which this row was first written.
+      6. ``modified``: The timestamp at which the student's criterion status last changed. Rows are updated in place (ADR 0003 Decision 5), so ``created`` alone cannot date the current status. Set when the stored status actually changes, not on every write: under the monotone merge (ADR 0004 Decision 2) a redelivered grade event commonly rewrites the same value, and dating that as a change would make this column mean "last written" instead. Django's ``auto_now`` implements the latter, and does not fire at all for ``queryset.update()`` or ``bulk_update()``.
 
    3. Add a new database table for ``StudentCompetencyCriteriaGroupStatus`` with these columns:
 
@@ -287,7 +289,8 @@ Decision
       2. ``competency_criteria_group_id``: Foreign key to ``CompetencyCriteriaGroup.id``
       3. ``user_id``: Foreign key pointing to user_id (presumably the learner's id, although it appears that it is possible for staff to get grades as well) in ``auth_user`` table
       4. ``status_id``: Foreign key to ``CompetencyMasteryStatuses.id``
-      5. ``created``: The timestamp at which the student's criteria-group status was set.
+      5. ``created``: The timestamp at which this row was first written.
+      6. ``modified``: The timestamp at which the student's criteria-group status last changed.
 
    4. Add a new database table for ``StudentCompetencyStatus`` with these columns:
 
@@ -295,7 +298,8 @@ Decision
       2. ``oel_tagging_tag_id``: Foreign key pointing to Tag id
       3. ``user_id``: Foreign key pointing to user_id (presumably the learner's id, although it appears that it is possible for staff to get grades as well) in ``auth_user`` table
       4. ``status_id``: Foreign key to ``CompetencyMasteryStatuses.id``. This table should have a constraint to only allow status values of “Demonstrated” and “PartiallyAttempted” since it represents overall competency demonstration state, not in-progress states.
-      5. ``created``: The timestamp at which the student's competency status was set.
+      5. ``created``: The timestamp at which this row was first written.
+      6. ``modified``: The timestamp at which the student's competency status last changed.
 
 7. Delete protection boundaries
 
@@ -430,3 +434,15 @@ Changelog
 
 * Made the learner status indexes unique, so there is one row per learner and node. This is what
   the in-place, monotone status updates in :ref:`openedx-learning-adr-0004` read, lock, and update.
+
+2026-08-11:
+
+* Gave each learner status table a ``modified`` timestamp and narrowed ``created`` to the row's
+  first write. In-place updates mean ``created`` no longer dates the current status, and adding the
+  column after the tables have rows would be a migration on the largest table in the schema
+  (:ref:`openedx-learning-adr-0005`).
+* Corrected the ``CompetencyRuleProfile.archived`` note to say archived profiles keep learner status
+  *rows* resolvable. It said "history", which :ref:`openedx-learning-adr-0005` does not provide.
+* Gave ``CompetencyMasteryStatuses`` a ``rank`` column. Without a stored ordering, the monotone merge
+  in :ref:`openedx-learning-adr-0004`, Decision 2 cannot be a single statement, and ``id`` does not
+  supply one: the seeded values are listed highest-first.

--- a/docs/openedx_learning/decisions/0002-competency-criteria-model.rst
+++ b/docs/openedx_learning/decisions/0002-competency-criteria-model.rst
@@ -240,11 +240,14 @@ Decision
    3. ``oel_tagging_objecttag(object_id)``
    4. ``CompetencyCriteria(oel_tagging_objecttag_id)``
    5. ``CompetencyCriteria(competency_criteria_group_id)``
-   6. ``StudentCompetencyCriteriaStatus(user_id, competency_criteria_id)``
-   7. ``StudentCompetencyCriteriaGroupStatus(user_id, competency_criteria_group_id)``
-   8. ``StudentCompetencyStatus(user_id, oel_tagging_tag_id)``
-   9. ``CompetencyRuleProfile(scope_code)`` (unique -- at most one profile per distinct scope value; a plain unique constraint on the three raw nullable scope columns would not enforce this, since SQL never treats two ``NULL`` values as equal and this project's MySQL backend does not support the conditional/partial unique indexes that would otherwise route around that; see the ``scope_code`` column in Decision 3)
-   10. ``CompetencyMasteryStatuses(status)`` (unique)
+   6. ``StudentCompetencyCriteriaStatus(user_id, competency_criteria_id)`` (unique)
+   7. ``StudentCompetencyCriteriaStatusHistory(user_id, competency_criteria_id, status_id)`` (unique -- at most one HISTORY row per learner, leaf, and status level, which also serves as the idempotency key for the append in :ref:`openedx-learning-adr-0004`)
+   8. ``StudentCompetencyCriteriaGroupStatus(user_id, competency_criteria_group_id)`` (unique)
+   9. ``StudentCompetencyCriteriaGroupStatusHistory(user_id, competency_criteria_group_id)``
+   10. ``StudentCompetencyStatus(user_id, oel_tagging_tag_id)`` (unique)
+   11. ``StudentCompetencyStatusHistory(user_id, oel_tagging_tag_id)``
+   12. ``CompetencyRuleProfile(scope_code)`` (unique -- at most one profile per distinct scope value; a plain unique constraint on the three raw nullable scope columns would not enforce this, since SQL never treats two ``NULL`` values as equal and this project's MySQL backend does not support the conditional/partial unique indexes that would otherwise route around that; see the ``scope_code`` column in Decision 3)
+   13. ``CompetencyMasteryStatuses(status)`` (unique)
 
 6. Learner progress status concepts (``StudentCompetency*Status`` database tables)
 
@@ -256,6 +259,12 @@ Decision
    - ``StudentCompetencyCriteriaGroupStatus`` tracks status at ``CompetencyCriteriaGroup`` node level.
    - ``StudentCompetencyStatus`` tracks top-level competency demonstration state.
    - All learner status rows use a shared lookup table (``CompetencyMasteryStatuses``) so status semantics live in one place and student status tables stay structurally consistent.
+
+   Append-only history tables:
+
+   - ``StudentCompetencyCriteriaStatusHistory``
+   - ``StudentCompetencyCriteriaGroupStatusHistory``
+   - ``StudentCompetencyStatusHistory``
 
    Intended update flow (bottom-up materialization):
 
@@ -422,3 +431,15 @@ Rejected Alternatives
 
       1. Silently does not work on this project's tested and production database backend. Django compiles a conditional ``UniqueConstraint`` to a partial index, which MySQL does not support; Django raises only a non-fatal system-check warning (``models.W036``) and skips creating the constraint, leaving the uniqueness rule completely unenforced at the database level.
       2. The gap would surface only as a data-integrity incident under concurrent writes, not as a test or migration failure, since SQLite (used for quick local test runs) does support partial indexes and would mask the problem in that environment.
+
+Changelog
+---------
+
+2026-07-27:
+
+* Split learner status storage into paired ACTIVE and HISTORY tables: added the append-only
+  ``StudentCompetencyCriteriaStatusHistory``, ``StudentCompetencyCriteriaGroupStatusHistory``,
+  and ``StudentCompetencyStatusHistory`` tables and their indexes alongside the in-place ACTIVE
+  tables, per :ref:`openedx-learning-adr-0005`.
+* Made the leaf HISTORY (``StudentCompetencyCriteriaStatusHistory``) index unique on ``(user_id, competency_criteria_id, status_id)``, the
+  idempotency key for the HISTORY append in :ref:`openedx-learning-adr-0004`.

--- a/docs/openedx_learning/decisions/0003-competency-criteria-versioning.rst
+++ b/docs/openedx_learning/decisions/0003-competency-criteria-versioning.rst
@@ -48,17 +48,9 @@ For the initial implementation, versioning and traceability of competency achiev
 
    - For ``StudentCompetencyCriteriaStatus``, ``StudentCompetencyCriteriaGroupStatus``, and ``StudentCompetencyStatus``,
      each status change updates the responsible row.
-   - Statuses only increase monotonically as described by :ref:`openedx-learning-adr-0005`;
+   - Statuses only increase monotonically, as relied on by :ref:`openedx-learning-adr-0004`;
      downward status adjustments (for example ``Demonstrated`` to ``PartiallyAttempted``) are prohibited.
-
-6. Learner status models/tables as in 5. above each get a separate append-only history table not using ``django-simple-history``:
-
-   - For ``StudentCompetencyCriteriaStatusHistory``, ``StudentCompetencyCriteriaGroupStatusHistory``, and ``StudentCompetencyStatusHistory``,
-     each status advance is stored as a new row with ``created`` as the write timestamp.
-   - Existing learner status rows are not updated in place in the history tables.
-   - Statuses only increase monotonically as described by :ref:`openedx-learning-adr-0005`;
-     if a change would mean a downward adjustment (for example ``Demonstrated`` to ``PartiallyAttempted``)
-     or no adjustment, this does not get stored in the history tables.
+   - How learner status history is retained is not decided here.
 
 
 Rejected Alternatives
@@ -100,7 +92,6 @@ Changelog
 
 2026-07-27:
 
-* Reworked learner status handling to match :ref:`openedx-learning-adr-0005` and
-  :ref:`openedx-learning-adr-0004`: Decision 5 now updates learner status rows in place and
-  monotonically (downward adjustments prohibited), and a new Decision 6 adds separate append-only
-  HISTORY tables. Previously a single append-only model with no in-place ACTIVE row.
+* Reworked Decision 5 for :ref:`openedx-learning-adr-0004`: learner status rows are now updated in
+  place and monotonically (downward adjustments prohibited). Previously append-only, with current
+  status resolved as the most recent row. How status history is retained is left undecided.

--- a/docs/openedx_learning/decisions/0003-competency-criteria-versioning.rst
+++ b/docs/openedx_learning/decisions/0003-competency-criteria-versioning.rst
@@ -44,12 +44,21 @@ For the initial implementation, versioning and traceability of competency achiev
    - A ``CompetencyRuleProfile`` is "in use" if any ``CompetencyCriterion`` assigned to it (``competency_rule_profile_id``) has an associated ``StudentCompetencyCriteriaStatus`` row. Editing an in-use profile's ``rule_type``/``rule_payload`` requires the same warning and confirmation.
    - The same warning applies when creating a more specific profile causes existing criteria to be reassigned to it, and when an authoring action switches a criterion between a profile assignment and per-criterion overrides (ADR 0002 Decision 4).
 
-5. Learner status models/tables are append-only history and do not use ``django-simple-history``:
+5. Learner status models/tables are updated in-place:
 
-   - For ``StudentCompetencyCriteriaStatus``, ``StudentCompetencyCriteriaGroupStatus``, and ``StudentCompetencyStatus``, each status change is stored as a new row with ``created`` as the write timestamp.
-   - Existing learner status rows are not updated in place.
-   - Current status is determined by the most recent row for a given learner + target entity (ordered by ``created``, with ``id`` as a tie-breaker).
-   - Older rows represent the learner status history and remain available for audit/tracing.
+   - For ``StudentCompetencyCriteriaStatus``, ``StudentCompetencyCriteriaGroupStatus``, and ``StudentCompetencyStatus``,
+     each status change updates the responsible row.
+   - Statuses only increase monotonically as described by :ref:`openedx-learning-adr-0005`;
+     downward status adjustments (for example ``Demonstrated`` to ``PartiallyAttempted``) are prohibited.
+
+6. Learner status models/tables as in 5. above each get a separate append-only history table not using ``django-simple-history``:
+
+   - For ``StudentCompetencyCriteriaStatusHistory``, ``StudentCompetencyCriteriaGroupStatusHistory``, and ``StudentCompetencyStatusHistory``,
+     each status advance is stored as a new row with ``created`` as the write timestamp.
+   - Existing learner status rows are not updated in place in the history tables.
+   - Statuses only increase monotonically as described by :ref:`openedx-learning-adr-0005`;
+     if a change would mean a downward adjustment (for example ``Demonstrated`` to ``PartiallyAttempted``)
+     or no adjustment, this does not get stored in the history tables.
 
 
 Rejected Alternatives
@@ -85,3 +94,13 @@ Rejected Alternatives
     - Cons:
         - Requires custom tooling to reconstruct past versions
         - Does not align with existing publishable versioning patterns
+
+Changelog
+---------
+
+2026-07-27:
+
+* Reworked learner status handling to match :ref:`openedx-learning-adr-0005` and
+  :ref:`openedx-learning-adr-0004`: Decision 5 now updates learner status rows in place and
+  monotonically (downward adjustments prohibited), and a new Decision 6 adds separate append-only
+  HISTORY tables. Previously a single append-only model with no in-place ACTIVE row.

--- a/docs/openedx_learning/decisions/0003-competency-criteria-versioning.rst
+++ b/docs/openedx_learning/decisions/0003-competency-criteria-versioning.rst
@@ -13,7 +13,7 @@ Typically, institutions and instructional designers do not change the mastery re
 
 Currently, Open edX always displays the latest edited version of content in the Studio UI and always shows the latest published version of content in the LMS UI, despite having more robust version tracking on the backend (Publishable Entities).
 
-Authoring data (criteria definitions) and runtime learner data (status) have different governance needs. The former is long-lived and typically non-PII, while the latter is user-specific, can be large (learners x criteria/competencies x time), and may require stricter retention and access controls. These differing lifecycles can make deep coupling of authoring and runtime data harder to manage at scale. Performance is also a consideration as computing or resolving versioned criteria for large courses could add overhead in Studio authoring screens or LMS views.
+Authoring data (criteria definitions) and runtime learner data (status) have different governance needs. The former is long-lived and typically non-PII, while the latter is user-specific, can be large (learners x criteria/competencies), and may require stricter retention and access controls. These differing lifecycles can make deep coupling of authoring and runtime data harder to manage at scale. Performance is also a consideration as computing or resolving versioned criteria for large courses could add overhead in Studio authoring screens or LMS views.
 
 Decision
 --------
@@ -55,7 +55,9 @@ For the initial implementation, versioning and traceability of competency achiev
    - Direct edits by staff, through Django admin or as a deliberate instructor correction, are
      exempt: they may set a status to any value, including a lower one, and the ancestors above the
      edited node are recomputed to match.
-   - How learner status history is retained is not decided here.
+   - How learner status history is retained is not decided here. See
+     :ref:`openedx-learning-adr-0005`, "Out of Scope", for what the current status rows can and
+     cannot account for, and for the constraints on whatever decides it.
 
 
 Rejected Alternatives
@@ -101,3 +103,11 @@ Changelog
   place, and automatic updates only ever increase a status, with direct staff edits exempt.
   Previously append-only, with current status resolved as the most recent row. How status history is
   retained is left undecided.
+
+2026-08-11:
+
+* Pointed Decision 5's undecided history question at :ref:`openedx-learning-adr-0005`, which owns
+  the deferral.
+* Dropped the "x time" factor from the Context's sizing of learner status data. It described the
+  append-only model that Decision 5 replaced; there is now one row per learner and node
+  (:ref:`openedx-learning-adr-0005`).

--- a/docs/openedx_learning/decisions/0003-competency-criteria-versioning.rst
+++ b/docs/openedx_learning/decisions/0003-competency-criteria-versioning.rst
@@ -48,8 +48,13 @@ For the initial implementation, versioning and traceability of competency achiev
 
    - For ``StudentCompetencyCriteriaStatus``, ``StudentCompetencyCriteriaGroupStatus``, and ``StudentCompetencyStatus``,
      each status change updates the responsible row.
-   - Statuses only increase monotonically, as relied on by :ref:`openedx-learning-adr-0004`;
-     downward status adjustments (for example ``Demonstrated`` to ``PartiallyAttempted``) are prohibited.
+   - Automatic status updates only ever increase a status, as relied on by
+     :ref:`openedx-learning-adr-0004`. A downward adjustment (for example ``Demonstrated`` to
+     ``PartiallyAttempted``) is never applied by a grade change or by a competency criteria rule
+     change.
+   - Direct edits by staff, through Django admin or as a deliberate instructor correction, are
+     exempt: they may set a status to any value, including a lower one, and the ancestors above the
+     edited node are recomputed to match.
    - How learner status history is retained is not decided here.
 
 
@@ -93,5 +98,6 @@ Changelog
 2026-07-27:
 
 * Reworked Decision 5 for :ref:`openedx-learning-adr-0004`: learner status rows are now updated in
-  place and monotonically (downward adjustments prohibited). Previously append-only, with current
-  status resolved as the most recent row. How status history is retained is left undecided.
+  place, and automatic updates only ever increase a status, with direct staff edits exempt.
+  Previously append-only, with current status resolved as the most recent row. How status history is
+  retained is left undecided.

--- a/docs/openedx_learning/decisions/0004-competency-mastery-concurrency.rst
+++ b/docs/openedx_learning/decisions/0004-competency-mastery-concurrency.rst
@@ -1,0 +1,137 @@
+.. _openedx-learning-adr-0004:
+
+4. How should learner competency mastery be recorded concurrently and at scale?
+================================================================================
+
+Status
+------
+Proposed.
+
+Context
+-------
+When a learner is graded on a subsection (or any other learning instrument associated to a competency
+with a competency criteria, like a course or rubric criterion), the platform must evaluate whether that grade
+demonstrates any attached competencies and record the learner's mastery. Mastery is recorded at
+three levels: the criterion (leaf), the criteria group, and the competency. Per
+:ref:`openedx-learning-adr-0002` and :ref:`openedx-learning-adr-0005`, all three levels are
+*materialized* (stored), not recomputed on read, so that dashboards and other read surfaces stay
+fast. A single grade change therefore writes the changed leaf's status and then re-evaluates and
+re-writes the derived rows from that leaf up to the competency root. The re-evaluation
+is needed for multiple reasons, including notifications, and badge and certificate issuing. Per
+:ref:`openedx-learning-adr-0005`, each level is stored as an ACTIVE row updated in place, holding
+the current status for a learner and node, plus an append-only HISTORY row per genuine status
+advance.
+
+**Monotonicity: competency statuses only ever move forward.** Per
+:ref:`openedx-learning-adr-0005`, every node, at every level, advances through a small status
+lattice (``AttemptedNotDemonstrated`` to ``PartiallyAttempted`` to ``Demonstrated``) and is never
+lowered later. This holds for leaf nodes, group nodes, and top-level competency masteries.
+
+Two forces shape how recording should happen:
+
+- **Same-learner correctness.** A grade change writes the changed leaf and then re-derives the
+  group and competency rows above it. Leaf rows are always correct, since each leaf is a pure
+  function of its own grade. The derived rows are the hazard: We want to avoid a case where two evaluations for the same learner
+  that overlap can each read a stale snapshot of the sibling leaf statuses and each write a derived
+  roll-up computed from an incomplete picture (a *write-skew*).
+
+- **Throughput.** Grading is bursty and spans a very large number of learners, so the recording
+  path must keep up under peak load.
+
+Decision
+--------
+
+**1. Every write is a monotone merge, never a blind overwrite.** A node's status is written as
+``status := max(stored status, newly computed status)`` (a single ``GREATEST``-style ``UPDATE``,
+atomic at the row for the duration of that one statement, with no application-level lock). Because
+the merge takes the higher of the two values, it is commutative, idempotent, and insensitive to
+order. This is why out-of-order delivery and re-delivery are harmless without sequence tracking.
+
+**2. When a child advances, its parent is recomputed in the same transaction, under a brief row lock on that parent.**
+The merge in mechanism 1 makes a single-row write safe, but a *conjunctive*
+parent (for example "demonstrated only when all children are demonstrated") is computed by reading
+several child rows first, so two overlapping evaluations for one learner could each read a stale
+sibling and compute a parent that is too low. To prevent that, recomputing a parent takes a
+row-level lock on the parent row (a ``SELECT ... FOR UPDATE``) before reading its children: two
+updates that touch the same parent for the same learner take turns, and the second reads the first's
+committed children and computes from the complete picture. This correctness argument assumes
+``READ COMMITTED`` isolation (the Open edX platform default on MySQL; higher isolation levels are not
+supported on the platform): under it the lock's own read and the sibling reads that follow it always
+return the latest committed rows, rather than a snapshot fixed at an earlier read in the same
+transaction, which is what a higher level such as ``REPEATABLE READ`` would do. Locks are taken child-before-parent up
+the path to the root, a consistent order, so concurrent updates cannot deadlock. This is an ordinary
+single-row lock.
+
+**3. Entry point: edx-platform subsection grade change.** edx-platform
+computes subsection grades in an async celery task (`recalculate_subsection_grade_v3`) triggered by a score-change signal, not on the
+request thread. After that task writes the subsection grade, it calls a public openedx-core function
+within the same transaction; this function does the monotone merge and the upward roll-up. This should be generalized as needed to other places that trigger a competency status update.
+
+**4. The ACTIVE writes, the HISTORY appends, and the roll-ups all commit atomically with the
+subsection grade.** The leaf, group, and competency ACTIVE writes from mechanisms 1 and 2, and the
+HISTORY row appended for each genuine advance, run inside the same transaction that mechanism 3
+opened for the subsection-grade write, so they commit as a single unit with it. If any step fails, that transaction rolls back and the task retries, leaving
+behind neither a partial roll-up nor an ACTIVE status whose advance went unrecorded. A unique
+constraint on the advance (learner, node, and status; :ref:`openedx-learning-adr-0002`) makes the
+append idempotent, so a retried task or a redelivered grade event collapses to a no-op rather than
+writing a duplicate row.
+
+**5. Only an advance is appended to HISTORY.** The monotone merge in mechanism 1 often leaves a status
+where it was, because the newly computed status equals or is lower than the stored one. Those writes
+append nothing: a redelivered grade event, a downward grade correction, and a recompute that confirms
+the current status all leave HISTORY untouched. So the recorder writes at most one HISTORY row per
+learner, node, and step up the lattice, which is what bounds HISTORY to the same order of magnitude as
+ACTIVE rather than to grading volume (:ref:`openedx-learning-adr-0005`).
+
+
+Rejected Alternatives
+---------------------
+
+1. Prevent concurrent writes with a coarser lock, either deployment-wide or per-learner.
+
+    - Pros:
+        - Correctness comes from a single lock rather than from the monotone-merge argument, so it is
+          simpler to reason about.
+        - A per-learner lock (for example a database advisory lock keyed on a hash of the user id)
+          still lets different learners record in parallel, and gives the same per-learner
+          serialization the chosen design relies on.
+    - Cons:
+        - A single deployment-wide lock serializes recording across every learner, giving up the
+          throughput the design needs under bursty grading.
+        - A per-learner lock still serializes a single learner's independent competencies against each
+          other even when they never contend.
+        - Either lock adds lock-lifecycle machinery (acquisition, release, and handling a holder that
+          dies) across a very large key space.
+        - The chosen design needs no such lock: the monotone merge (mechanism 1) makes each single-row
+          write safe, and the brief per-parent row lock (mechanism 2) serializes only writers that
+          actually contend for the same parent row of the same learner, so different learners, and
+          different competencies of one learner, still record in parallel.
+
+2. Recompute derived levels on read instead of materializing them.
+
+    - Pros:
+        - Eliminates the derived group and competency status rows and the roll-up writes entirely,
+          leaving nothing to keep consistent on write.
+    - Cons:
+        - Moves the full bottom-up tree evaluation onto the hot read path, the opposite of what
+          dashboards and other read surfaces need (a direct indexed lookup).
+        - Settled against in :ref:`openedx-learning-adr-0002`.
+
+3. Send an event to openedx-core and update competency statuses in a separate celery task.
+
+    - Pros:
+        - Decouples the mastery update from the grade write, so grade recording does not depend on
+          competency code being installed or fast.
+    - Cons:
+        - Without a shared transaction, a failure or a lost event leaves the grade and its mastery rows
+          permanently out of sync (data drift), with no way to roll them back together.
+        - Recording the ACTIVE writes in the same transaction as the grade (mechanism 3) instead makes
+          the grade and its mastery consequences commit or fail as a unit.
+
+4. Append the leaf HISTORY row outside the grade transaction, as a retrying task dispatched with
+   ``transaction.on_commit``.
+
+    This would be mandatory if the HISTORY table were ever
+    routed to a separate database alias, since a write on another connection cannot be atomic
+    with the primary transaction. Since we decided that every status table lives in the main database
+    (:ref:`openedx-learning-adr-0005`), this is unnecessary.

--- a/docs/openedx_learning/decisions/0004-competency-mastery-concurrency.rst
+++ b/docs/openedx_learning/decisions/0004-competency-mastery-concurrency.rst
@@ -13,17 +13,16 @@ When a learner is graded on a subsection (or any other learning instrument assoc
 with a competency criteria, like a course or rubric criterion), the platform must evaluate whether that grade
 demonstrates any attached competencies and record the learner's mastery. Mastery is recorded at
 three levels: the criterion (leaf), the criteria group, and the competency. Per
-:ref:`openedx-learning-adr-0002` and :ref:`openedx-learning-adr-0005`, all three levels are
+:ref:`openedx-learning-adr-0002`, all three levels are
 *materialized* (stored), not recomputed on read, so that dashboards and other read surfaces stay
 fast. A single grade change therefore writes the changed leaf's status and then re-evaluates and
 re-writes the derived rows from that leaf up to the competency root. The re-evaluation
 is needed for multiple reasons, including notifications, and badge and certificate issuing. Per
-:ref:`openedx-learning-adr-0005`, each level is stored as an ACTIVE row updated in place, holding
-the current status for a learner and node, plus an append-only HISTORY row per genuine status
-advance.
+:ref:`openedx-learning-adr-0003`, each level is stored as one row per learner and node, updated in
+place, holding that learner's current status for that node.
 
 **Monotonicity: competency statuses only ever move forward.** Per
-:ref:`openedx-learning-adr-0005`, every node, at every level, advances through a small status
+:ref:`openedx-learning-adr-0003`, every node, at every level, advances through a small status
 lattice (``AttemptedNotDemonstrated`` to ``PartiallyAttempted`` to ``Demonstrated``) and is never
 lowered later. This holds for leaf nodes, group nodes, and top-level competency masteries.
 
@@ -67,21 +66,11 @@ computes subsection grades in an async celery task (`recalculate_subsection_grad
 request thread. After that task writes the subsection grade, it calls a public openedx-core function
 within the same transaction; this function does the monotone merge and the upward roll-up. This should be generalized as needed to other places that trigger a competency status update.
 
-**4. The ACTIVE writes, the HISTORY appends, and the roll-ups all commit atomically with the
-subsection grade.** The leaf, group, and competency ACTIVE writes from mechanisms 1 and 2, and the
-HISTORY row appended for each genuine advance, run inside the same transaction that mechanism 3
-opened for the subsection-grade write, so they commit as a single unit with it. If any step fails, that transaction rolls back and the task retries, leaving
-behind neither a partial roll-up nor an ACTIVE status whose advance went unrecorded. A unique
-constraint on the advance (learner, node, and status; :ref:`openedx-learning-adr-0002`) makes the
-append idempotent, so a retried task or a redelivered grade event collapses to a no-op rather than
-writing a duplicate row.
-
-**5. Only an advance is appended to HISTORY.** The monotone merge in mechanism 1 often leaves a status
-where it was, because the newly computed status equals or is lower than the stored one. Those writes
-append nothing: a redelivered grade event, a downward grade correction, and a recompute that confirms
-the current status all leave HISTORY untouched. So the recorder writes at most one HISTORY row per
-learner, node, and step up the lattice, which is what bounds HISTORY to the same order of magnitude as
-ACTIVE rather than to grading volume (:ref:`openedx-learning-adr-0005`).
+**4. The status writes and the roll-ups all commit atomically with the subsection grade.** The
+leaf, group, and competency status writes from mechanisms 1 and 2 run inside the same transaction
+that mechanism 3 opened for the subsection-grade write, so they commit as a single unit with it. If
+any step fails, that transaction rolls back and the task retries, leaving behind no partial
+roll-up.
 
 
 Rejected Alternatives
@@ -125,13 +114,5 @@ Rejected Alternatives
     - Cons:
         - Without a shared transaction, a failure or a lost event leaves the grade and its mastery rows
           permanently out of sync (data drift), with no way to roll them back together.
-        - Recording the ACTIVE writes in the same transaction as the grade (mechanism 3) instead makes
+        - Recording the status writes in the same transaction as the grade (mechanism 3) instead makes
           the grade and its mastery consequences commit or fail as a unit.
-
-4. Append the leaf HISTORY row outside the grade transaction, as a retrying task dispatched with
-   ``transaction.on_commit``.
-
-    This would be mandatory if the HISTORY table were ever
-    routed to a separate database alias, since a write on another connection cannot be atomic
-    with the primary transaction. Since we decided that every status table lives in the main database
-    (:ref:`openedx-learning-adr-0005`), this is unnecessary.

--- a/docs/openedx_learning/decisions/0004-competency-mastery-concurrency.rst
+++ b/docs/openedx_learning/decisions/0004-competency-mastery-concurrency.rst
@@ -21,10 +21,25 @@ is needed for multiple reasons, including notifications, and badge and certifica
 :ref:`openedx-learning-adr-0003`, each level is stored as one row per learner and node, updated in
 place, holding that learner's current status for that node.
 
-**Monotonicity: competency statuses only ever move forward.** Per
+**Monotonicity: the recorder only ever moves a status forward.** Per
 :ref:`openedx-learning-adr-0003`, every node, at every level, advances through a small status
 lattice (``AttemptedNotDemonstrated`` to ``PartiallyAttempted`` to ``Demonstrated``) and is never
-lowered later. This holds for leaf nodes, group nodes, and top-level competency masteries.
+lowered by the recorder. This holds for leaf nodes, group nodes, and top-level competency masteries,
+and against both of the recorder's triggers: neither a downward grade correction nor a change to the
+competency criteria rules lowers a recorded status.
+
+Monotonicity is a property of that automatic path, not an invariant of the stored data. Staff can
+set a learner's status directly, through Django admin or as a deliberate instructor correction, and
+such an edit may move a status backward. A direct edit does cascade: the ancestors above the edited
+node are recomputed up to the competency root, so an instructor correcting a leaf from
+``Demonstrated`` to ``AttemptedNotDemonstrated`` lowers the group and competency rows above it too.
+That cascade cannot use the monotone merge of mechanism 1, which by construction never lowers
+anything, so it overwrites each ancestor with the freshly computed value instead. It does take the
+same parent locks as mechanism 2, so it orders correctly against concurrent recorder writes.
+
+Because the recorder never lowers a status, a direct edit is the only thing that can. A later grade
+change re-merges against whatever the edit left behind: it can raise a status an edit lowered, but
+it can never re-lower one an edit raised.
 
 Two forces shape how recording should happen:
 
@@ -40,7 +55,7 @@ Two forces shape how recording should happen:
 Decision
 --------
 
-**1. Every write is a monotone merge, never a blind overwrite.** A node's status is written as
+**1. Every recorder write is a monotone merge, never a blind overwrite.** A node's status is written as
 ``status := max(stored status, newly computed status)`` (a single ``GREATEST``-style ``UPDATE``,
 atomic at the row for the duration of that one statement, with no application-level lock). Because
 the merge takes the higher of the two values, it is commutative, idempotent, and insensitive to
@@ -71,6 +86,23 @@ leaf, group, and competency status writes from mechanisms 1 and 2 run inside the
 that mechanism 3 opened for the subsection-grade write, so they commit as a single unit with it. If
 any step fails, that transaction rolls back and the task retries, leaving behind no partial
 roll-up.
+
+
+Open Questions
+--------------
+
+1. **Confirm that a direct staff edit cascades to ancestors.** The Context above decides that it
+   does: correcting a learner's leaf status by hand recomputes the group and competency rows above
+   it, downward if that is what the rules produce. The alternative is to leave the ancestors
+   untouched and require a separate reconciliation step. Cascading is what an instructor issuing a
+   correction would expect, but it costs something: the recorder is no longer the only writer that
+   can lower a status, and a stored ancestor status is no longer a pure function of the recorder's
+   own history. This decision should be confirmed before implementation.
+
+2. **Decide whether a cascade may overwrite a hand-set ancestor.** If a staff user has set a group
+   or competency status directly, and a later direct edit below it cascades upward, the recomputed
+   value overwrites the hand-set one. Whether a hand-set ancestor should instead survive the
+   cascade is undecided.
 
 
 Rejected Alternatives

--- a/docs/openedx_learning/decisions/0004-competency-mastery-concurrency.rst
+++ b/docs/openedx_learning/decisions/0004-competency-mastery-concurrency.rst
@@ -9,45 +9,44 @@ Proposed.
 
 Context
 -------
-When a learner is graded on a subsection (or any other learning instrument associated to a competency
-with a competency criteria, like a course or rubric criterion), the platform must evaluate whether that grade
-demonstrates any attached competencies and record the learner's mastery. Mastery is recorded at
-three levels: the criterion (leaf), the criteria group, and the competency. Per
-:ref:`openedx-learning-adr-0002`, all three levels are
-*materialized* (stored), not recomputed on read, so that dashboards and other read surfaces stay
-fast. A single grade change therefore writes the changed leaf's status and then re-evaluates and
-re-writes the derived rows from that leaf up to the competency root. The re-evaluation
-is needed for multiple reasons, including notifications, and badge and certificate issuing. Per
-:ref:`openedx-learning-adr-0003`, each level is stored as one row per learner and node, updated in
-place, holding that learner's current status for that node.
+When a learner is graded on a subsection, the platform must work out whether that grade demonstrates
+any attached competencies, and record it. The same goes for any other learning instrument tied to a
+competency by a competency criterion, such as a course or a rubric criterion.
 
-**Monotonicity: the recorder only ever moves a status forward.** Per
-:ref:`openedx-learning-adr-0003`, every node, at every level, advances through a small status
-lattice (``AttemptedNotDemonstrated`` to ``PartiallyAttempted`` to ``Demonstrated``) and is never
-lowered by the recorder. This holds for leaf nodes, group nodes, and top-level competency masteries,
-and against both of the recorder's triggers: neither a downward grade correction nor a change to the
-competency criteria rules lowers a recorded status.
+Mastery is recorded at three levels: the criterion (leaf), the criteria group, and the competency.
+Per :ref:`openedx-learning-adr-0002`, all three are stored rather than recomputed on read, so that
+dashboards and other read surfaces stay fast. Per :ref:`openedx-learning-adr-0003`, each level keeps
+one row per learner and node, updated in place.
 
-Monotonicity is a property of that automatic path, not an invariant of the stored data. Staff can
-set a learner's status directly, through Django admin or as a deliberate instructor correction, and
-such an edit may move a status backward. A direct edit does cascade: the ancestors above the edited
-node are recomputed up to the competency root, so an instructor correcting a leaf from
-``Demonstrated`` to ``AttemptedNotDemonstrated`` lowers the group and competency rows above it too.
-That cascade cannot use the monotone merge of mechanism 1, which by construction never lowers
-anything, so it overwrites each ancestor with the freshly computed value instead. It does take the
-same parent locks as mechanism 2, so it orders correctly against concurrent recorder writes.
+So a single grade change writes the changed leaf's status, then re-evaluates and re-writes every
+derived row from that leaf up to the competency root. The roll-up is not only for reads: it also
+drives notifications, badges, and certificate issuing.
 
-Because the recorder never lowers a status, a direct edit is the only thing that can. A later grade
-change re-merges against whatever the edit left behind: it can raise a status an edit lowered, but
-it can never re-lower one an edit raised.
+**Monotonicity: the recorder only ever moves a status forward.** Every node advances through a small
+status lattice (``AttemptedNotDemonstrated`` to ``PartiallyAttempted`` to ``Demonstrated``), and the
+recorder never lowers it (:ref:`openedx-learning-adr-0003`). That holds at all three levels, and for
+both of the recorder's triggers: neither a downward grade correction nor a change to the competency
+criteria rules lowers a recorded status.
+
+Monotonicity is a property of that automatic path, not of the stored data. Staff can set a learner's
+status directly, through Django admin or as a deliberate instructor correction, and a direct edit
+may lower it. A direct edit also cascades: the ancestors above the edited node are recomputed up to
+the root, so an instructor correcting a leaf from ``Demonstrated`` to ``AttemptedNotDemonstrated``
+lowers the group and competency rows above it too. That cascade cannot use the monotone merge of
+mechanism 1, which never lowers anything, so it overwrites each ancestor with the freshly computed
+value. It does take the same parent locks as mechanism 2, so it stays ordered against concurrent
+recorder writes.
+
+One consequence: a direct edit is the only thing that can lower a status. A later grade change
+merges against whatever the edit left behind, so it can raise a status an edit lowered, but it can
+never re-lower one an edit raised.
 
 Two forces shape how recording should happen:
 
-- **Same-learner correctness.** A grade change writes the changed leaf and then re-derives the
-  group and competency rows above it. Leaf rows are always correct, since each leaf is a pure
-  function of its own grade. The derived rows are the hazard: We want to avoid a case where two evaluations for the same learner
-  that overlap can each read a stale snapshot of the sibling leaf statuses and each write a derived
-  roll-up computed from an incomplete picture (a *write-skew*).
+- **Same-learner correctness.** Leaf rows are never in doubt, since each leaf is a pure function of
+  its own grade. The derived rows are the hazard. Two evaluations for the same learner that overlap
+  can each read a stale snapshot of the sibling leaf statuses, and each write a roll-up computed
+  from an incomplete picture.
 
 - **Throughput.** Grading is bursty and spans a very large number of learners, so the recording
   path must keep up under peak load.
@@ -55,41 +54,44 @@ Two forces shape how recording should happen:
 Decision
 --------
 
-**1. Every recorder write is a monotone merge, never a blind overwrite.** A node's status is written as
-``status := max(stored status, newly computed status)`` (a single ``GREATEST``-style ``UPDATE``,
-with no application-level lock; the database holds that row's exclusive lock until the transaction
-commits, which is what mechanism 2's lock ordering relies on). Because
-the merge takes the higher of the two values, it is commutative, idempotent, and insensitive to
-order. This is why out-of-order delivery and re-delivery are harmless without sequence tracking.
+**1. A recorder write only ever advances the stored value.** Every write is
+``status := max(stored status, newly computed status)``, a single ``GREATEST``-style ``UPDATE`` with
+no application-level lock. Taking the higher of the two values makes the write idempotent and
+insensitive to order, so out-of-order delivery and re-delivery are harmless without sequence
+tracking. The database holds that row's exclusive lock until the transaction commits, which is what
+mechanism 2's lock ordering relies on.
 
-**2. When a child advances, its parent is recomputed in the same transaction, under a brief row lock on that parent.**
-The merge in mechanism 1 makes a single-row write safe, but a *conjunctive*
-parent (for example "demonstrated only when all children are demonstrated") is computed by reading
-several child rows first, so two overlapping evaluations for one learner could each read a stale
-sibling and compute a parent that is too low. To prevent that, recomputing a parent takes a
-row-level lock on the parent row (a ``SELECT ... FOR UPDATE``) before reading its children: two
-updates that touch the same parent for the same learner take turns, and the second reads the first's
-committed children and computes from the complete picture. This correctness argument assumes
-``READ COMMITTED`` isolation (Django's default for MySQL, which the platform does not override):
-under it the lock's own read and the sibling reads that follow it always
-return the latest committed rows, rather than a snapshot fixed at an earlier read in the same
-transaction, which is what a higher level such as ``REPEATABLE READ`` would do. Locks are taken
-child-before-parent up the path to the root. Because the criteria tree gives every node exactly one
-parent (:ref:`openedx-learning-adr-0002`), that path is unique, so two updates that touch the same
-ancestor always reach it in the same order and cannot deadlock. Where one grade change advances
-several leaves at once, because a subsection carries several criteria, those leaves are locked in
-primary-key order for the same reason. This is an ordinary single-row lock.
+**2. When a child advances, its parent is recomputed in the same transaction, under a row lock on
+the parent.** A parent's rule can be conjunctive, for example "demonstrated only when all children
+are demonstrated", so recomputing it means reading all of its children first. If two children of one
+parent advance at the same time, each recomputation could read the other child's old value and write
+a parent status that is too low.
 
-**3. Entry point: edx-platform subsection grade change.** edx-platform
-computes subsection grades in an async celery task (``recalculate_subsection_grade_v3``) triggered by a score-change signal, not on the
-request thread. After that task writes the subsection grade, it calls a public openedx-core function
-within the same transaction; this function does the monotone merge and the upward roll-up. This should be generalized as needed to other places that trigger a competency status update.
+To prevent that, a recomputation locks the parent row (``SELECT ... FOR UPDATE``) before reading the
+children. The two writers take turns, and the second reads the first's committed children.
 
-**4. The status writes and the roll-ups all commit atomically with the subsection grade.** The
-leaf, group, and competency status writes from mechanisms 1 and 2 run inside the same transaction
-that mechanism 3 opened for the subsection-grade write, so they commit as a single unit with it. If
-any step fails, that transaction rolls back and the task retries, leaving behind no partial
-roll-up.
+This relies on ``READ COMMITTED`` isolation, Django's default for MySQL, which the platform does not
+override. Under it, the child reads that follow the lock return the latest committed rows. Under
+``REPEATABLE READ`` they would instead return a snapshot fixed at an earlier read in the same
+transaction, and the second writer would still see the stale child.
+
+Locks are taken child-before-parent, up the path to the root. The criteria tree gives every node
+exactly one parent (:ref:`openedx-learning-adr-0002`), so that path is unique, and two transactions
+touching the same ancestor always reach it in the same order. They cannot deadlock. Where one grade
+change advances several leaves at once, because a subsection carries several criteria, those leaves
+are locked in primary-key order for the same reason.
+
+**3. Entry point: a subsection grade change in edx-platform.** edx-platform computes subsection
+grades in an async celery task (``recalculate_subsection_grade_v3``) triggered by a score-change
+signal, not on the request thread. After that task writes the subsection grade, it calls a public
+openedx-core function in the same transaction, which does the merge and the roll-up. As other kinds
+of competency criteria are defined, completion for example, further entry points will call that same
+function.
+
+**4. The status writes and the roll-ups commit atomically with the subsection grade.** The leaf,
+group, and competency writes from mechanisms 1 and 2 run inside the transaction that mechanism 3
+opened for the subsection-grade write, so they commit as one unit with it. If any step fails, the
+transaction rolls back and the task retries, leaving no partial roll-up behind.
 
 
 Open Questions
@@ -128,7 +130,7 @@ Rejected Alternatives
         - Either lock adds lock-lifecycle machinery (acquisition, release, and handling a holder that
           dies) across a very large key space.
         - The chosen design needs no such lock: the monotone merge (mechanism 1) makes each single-row
-          write safe, and the brief per-parent row lock (mechanism 2) serializes only writers that
+          write safe, and the per-parent row lock (mechanism 2) serializes only writers that
           actually contend for the same parent row of the same learner, so different learners, and
           different competencies of one learner, still record in parallel.
 

--- a/docs/openedx_learning/decisions/0004-competency-mastery-concurrency.rst
+++ b/docs/openedx_learning/decisions/0004-competency-mastery-concurrency.rst
@@ -9,107 +9,61 @@ Proposed.
 
 Context
 -------
-When a learner is graded on a subsection, the platform must work out whether that grade demonstrates
-any attached competencies, and record it. The same goes for any other learning instrument tied to a
-competency by a competency criterion, such as a course or a rubric criterion.
+A learner's mastery of one competency is stored at three levels of the competency criteria tree:
+the leaf criterion that was graded, each criteria group above it, and the competency itself. There
+is one row per learner and node, updated in place (:ref:`openedx-learning-adr-0002`,
+:ref:`openedx-learning-adr-0003`). Each row holds one of three values, lowest to highest:
+``AttemptedNotDemonstrated``, ``PartiallyAttempted``, ``Demonstrated``.
+So one grade change updates the leaf and then every row above
+it, for a very large number of learners, in bursts. This ADR decides how those writes stay correct
+when two of them for the same learner overlap.
 
-Mastery is recorded at three levels: the criterion (leaf), the criteria group, and the competency.
-Per :ref:`openedx-learning-adr-0002`, all three are stored rather than recomputed on read, so that
-dashboards and other read surfaces stay fast. Per :ref:`openedx-learning-adr-0003`, each level keeps
-one row per learner and node, updated in place.
-
-So a single grade change writes the changed leaf's status, then re-evaluates and re-writes every
-derived row from that leaf up to the competency root. The roll-up is not only for reads: it also
-drives notifications, badges, and certificate issuing.
-
-**Monotonicity: the recorder only ever moves a status forward.** Every node advances through a small
-status lattice (``AttemptedNotDemonstrated`` to ``PartiallyAttempted`` to ``Demonstrated``), and the
-recorder never lowers it (:ref:`openedx-learning-adr-0003`). That holds at all three levels, and for
-both of the recorder's triggers: neither a downward grade correction nor a change to the competency
-criteria rules lowers a recorded status.
-
-Monotonicity is a property of that automatic path, not of the stored data. Staff can set a learner's
-status directly, through Django admin or as a deliberate instructor correction, and a direct edit
-may lower it. A direct edit also cascades: the ancestors above the edited node are recomputed up to
-the root, so an instructor correcting a leaf from ``Demonstrated`` to ``AttemptedNotDemonstrated``
-lowers the group and competency rows above it too. That cascade cannot use the monotone merge of
-mechanism 1, which never lowers anything, so it overwrites each ancestor with the freshly computed
-value. It does take the same parent locks as mechanism 2, so it stays ordered against concurrent
-recorder writes.
-
-One consequence: a direct edit is the only thing that can lower a status. A later grade change
-merges against whatever the edit left behind, so it can raise a status an edit lowered, but it can
-never re-lower one an edit raised.
-
-Two forces shape how recording should happen:
-
-- **Same-learner correctness.** Leaf rows are never in doubt, since each leaf is a pure function of
-  its own grade. The derived rows are the hazard. Two evaluations for the same learner that overlap
-  can each read a stale snapshot of the sibling leaf statuses, and each write a roll-up computed
-  from an incomplete picture.
-
-- **Throughput.** Grading is bursty and spans a very large number of learners, so the recording
-  path must keep up under peak load.
+What triggers a change is a subsection grade, or any other learning instrument tied to a
+competency by a competency criterion, such as a course grade or a rubric criterion. The rows above
+the leaf are stored rather than recomputed on read because they also drive notifications, badges,
+and certificate issuing, so the roll-up has to happen when the grade does either way.
 
 Decision
 --------
 
-**1. A recorder write only ever advances the stored value.** Every write is
-``status := max(stored status, newly computed status)``, a single ``GREATEST``-style ``UPDATE`` with
-no application-level lock. Taking the higher of the two values makes the write idempotent and
-insensitive to order, so out-of-order delivery and re-delivery are harmless without sequence
-tracking. The database holds that row's exclusive lock until the transaction commits, which is what
-mechanism 2's lock ordering relies on.
+1. **The platform's grading task calls one openedx-core function, in the same atomic transaction as the
+   grade write.** Subsection grading already happens in a celery task; that task writes the grade
+   and then calls this function, which updates the leaf and walks up. Writing up the tree stops
+   where :ref:`openedx-learning-adr-0002`, Decision 6 says it stops.
 
-**2. When a child advances, its parent is recomputed in the same transaction, under a row lock on
-the parent.** A parent's rule can be conjunctive, for example "demonstrated only when all children
-are demonstrated", so recomputing it means reading all of its children first. If two children of one
-parent advance at the same time, each recomputation could read the other child's old value and write
-a parent status that is too low.
+2. **Automatic updates only move a status up: each write stores the higher of the stored value and
+   the newly computed one.** This makes the recorder safe
+   against celery delivering the same work twice or out of order. Applying one grade event twice
+   lands on the same value as applying it once.
 
-To prevent that, a recomputation locks the parent row (``SELECT ... FOR UPDATE``) before reading the
-children. The two writers take turns, and the second reads the first's committed children.
+3. **Before recomputing a group, lock that group's row.**
+   If two children advance at the same moment, each recomputation could read the other child as not yet
+   advanced. Both would then compute the same too-low value. Locking the group first makes the two writers take turns, so the
+   second one reads the first's committed children. Handling deadlocks is needed: see Unresolved 1.
 
-This relies on ``READ COMMITTED`` isolation, Django's default for MySQL, which the platform does not
-override. Under it, the child reads that follow the lock return the latest committed rows. Under
-``REPEATABLE READ`` they would instead return a snapshot fixed at an earlier read in the same
-transaction, and the second writer would still see the stale child.
+4. **A direct staff edit is the exception to all of the above.** An instructor or admin correcting
+   a status by hand may set any value, including a lower one, and the rows above the edited one are
+   recomputed and overwritten rather than merged, including any an earlier staff edit set by hand.
+   So a staff edit or a Django admin change is the only thing that can lower
+   a status, and a later grade change can raise what an edit lowered but can never re-lower what an
+   edit raised.
 
-Locks are taken child-before-parent, up the path to the root. The criteria tree gives every node
-exactly one parent (:ref:`openedx-learning-adr-0002`), so that path is unique, and two transactions
-touching the same ancestor always reach it in the same order. They cannot deadlock. Where one grade
-change advances several leaves at once, because a subsection carries several criteria, those leaves
-are locked in primary-key order for the same reason.
+Unresolved
+----------
 
-**3. Entry point: a subsection grade change in edx-platform.** edx-platform computes subsection
-grades in an async celery task (``recalculate_subsection_grade_v3``) triggered by a score-change
-signal, not on the request thread. After that task writes the subsection grade, it calls a public
-openedx-core function in the same transaction, which does the merge and the roll-up. As other kinds
-of competency criteria are defined, completion for example, further entry points will call that same
-function.
+1. How to avoid deadlocks on competency group node locks that a) involve a grade change locking one group and
+   b) involve a grade change locking multiple groups, which happens when one subsection manifests as multiple leafs
+   in the same tree.
+2. How notifications, badges, and certificates learn that a row moved.
 
-**4. The status writes and the roll-ups commit atomically with the subsection grade.** The leaf,
-group, and competency writes from mechanisms 1 and 2 run inside the transaction that mechanism 3
-opened for the subsection-grade write, so they commit as one unit with it. If any step fails, the
-transaction rolls back and the task retries, leaving no partial roll-up behind.
+Assumptions
+-----------
 
-
-Open Questions
---------------
-
-1. **Confirm that a direct staff edit cascades to ancestors.** The Context above decides that it
-   does: correcting a learner's leaf status by hand recomputes the group and competency rows above
-   it, downward if that is what the rules produce. The alternative is to leave the ancestors
-   untouched and require a separate reconciliation step. Cascading is what an instructor issuing a
-   correction would expect, but it costs something: the recorder is no longer the only writer that
-   can lower a status, and a stored ancestor status is no longer a pure function of the recorder's
-   own history. This decision should be confirmed before implementation.
-
-2. **Decide whether a cascade may overwrite a hand-set ancestor.** If a staff user has set a group
-   or competency status directly, and a later direct edit below it cascades upward, the recomputed
-   value overwrites the hand-set one. Whether a hand-set ancestor should instead survive the
-   cascade is undecided.
-
+1. Connections run at ``READ COMMITTED`` isolation. Decision 3 depends on it: the read taken after
+   the lock has to see current data rather than a snapshot from earlier in the transaction. MySQL's
+   own default is ``REPEATABLE READ``, but Django overrides it to ``READ COMMITTED`` on every
+   connection and edx-platform leaves that alone. A deployment that changes the setting breaks
+   decision 3 with no error and no failing test.
 
 Rejected Alternatives
 ---------------------
@@ -117,22 +71,23 @@ Rejected Alternatives
 1. Prevent concurrent writes with a coarser lock, either deployment-wide or per-learner.
 
     - Pros:
-        - Correctness comes from a single lock rather than from the monotone-merge argument, so it is
-          simpler to reason about.
+        - Correctness comes from a single lock rather than from the merge argument in Decision 2,
+          so it is simpler to reason about.
         - A per-learner lock (for example a database advisory lock keyed on a hash of the user id)
           still lets different learners record in parallel, and gives the same per-learner
           serialization the chosen design relies on.
     - Cons:
         - A single deployment-wide lock serializes recording across every learner, giving up the
           throughput the design needs under bursty grading.
-        - A per-learner lock still serializes a single learner's independent competencies against each
-          other even when they never contend.
-        - Either lock adds lock-lifecycle machinery (acquisition, release, and handling a holder that
-          dies) across a very large key space.
-        - The chosen design needs no such lock: the monotone merge (mechanism 1) makes each single-row
-          write safe, and the per-parent row lock (mechanism 2) serializes only writers that
-          actually contend for the same parent row of the same learner, so different learners, and
-          different competencies of one learner, still record in parallel.
+        - A per-learner lock still serializes a single learner's independent competencies against
+          each other even when they never contend.
+        - Either lock adds lock-lifecycle machinery (acquisition, release, and handling a holder
+          that dies) across a very large key space.
+        - The chosen design needs no lock beyond the row locks the database already takes for the
+          statements it issues: the merge (Decision 2) makes each single-row write safe, and the
+          parent row lock (Decision 3) serializes only writers that actually contend for the same
+          parent row of the same learner, so different learners, and different competencies of one
+          learner, still record in parallel.
 
 2. Recompute derived levels on read instead of materializing them.
 
@@ -150,7 +105,26 @@ Rejected Alternatives
         - Decouples the mastery update from the grade write, so grade recording does not depend on
           competency code being installed or fast.
     - Cons:
-        - Without a shared transaction, a failure or a lost event leaves the grade and its mastery rows
-          permanently out of sync (data drift), with no way to roll them back together.
-        - Recording the status writes in the same transaction as the grade (mechanism 3) instead makes
-          the grade and its mastery consequences commit or fail as a unit.
+        - Without a shared transaction, a failure or a lost event leaves the grade and its mastery
+          rows permanently out of sync (data drift), with no way to roll them back together.
+        - Writing the statuses in the same transaction as the grade (Decision 1) instead makes the
+          grade and its mastery consequences commit or fail as a unit.
+
+4. Commit the leaf, then re-read the leaves before rolling up, with no lock.
+
+    - Pros:
+        - Correct, and lock-free. Every writer commits its leaf before reading, so whichever writer
+          reads last sees every leaf already committed and computes the true value; the merge in
+          Decision 2 keeps it.
+    - Cons:
+        - The leaf has to commit before the roll-up reads, so the roll-up cannot share the grade's
+          transaction, which reopens the partial-failure window Decision 1 exists to close.
+
+5. Detect conflicts optimistically: a version column plus a unique constraint, and the losing write
+   retries.
+
+    - Pros:
+        - Contention costs a retry rather than a wait, so no writer ever blocks.
+    - Cons:
+        - Every writer needs conflict handling and a retry loop, and repeated contention on one
+          parent multiplies retries. The row lock in Decision 3 reaches the same result by waiting.

--- a/docs/openedx_learning/decisions/0004-competency-mastery-concurrency.rst
+++ b/docs/openedx_learning/decisions/0004-competency-mastery-concurrency.rst
@@ -57,7 +57,8 @@ Decision
 
 **1. Every recorder write is a monotone merge, never a blind overwrite.** A node's status is written as
 ``status := max(stored status, newly computed status)`` (a single ``GREATEST``-style ``UPDATE``,
-atomic at the row for the duration of that one statement, with no application-level lock). Because
+with no application-level lock; the database holds that row's exclusive lock until the transaction
+commits, which is what mechanism 2's lock ordering relies on). Because
 the merge takes the higher of the two values, it is commutative, idempotent, and insensitive to
 order. This is why out-of-order delivery and re-delivery are harmless without sequence tracking.
 
@@ -69,15 +70,18 @@ sibling and compute a parent that is too low. To prevent that, recomputing a par
 row-level lock on the parent row (a ``SELECT ... FOR UPDATE``) before reading its children: two
 updates that touch the same parent for the same learner take turns, and the second reads the first's
 committed children and computes from the complete picture. This correctness argument assumes
-``READ COMMITTED`` isolation (the Open edX platform default on MySQL; higher isolation levels are not
-supported on the platform): under it the lock's own read and the sibling reads that follow it always
+``READ COMMITTED`` isolation (Django's default for MySQL, which the platform does not override):
+under it the lock's own read and the sibling reads that follow it always
 return the latest committed rows, rather than a snapshot fixed at an earlier read in the same
-transaction, which is what a higher level such as ``REPEATABLE READ`` would do. Locks are taken child-before-parent up
-the path to the root, a consistent order, so concurrent updates cannot deadlock. This is an ordinary
-single-row lock.
+transaction, which is what a higher level such as ``REPEATABLE READ`` would do. Locks are taken
+child-before-parent up the path to the root. Because the criteria tree gives every node exactly one
+parent (:ref:`openedx-learning-adr-0002`), that path is unique, so two updates that touch the same
+ancestor always reach it in the same order and cannot deadlock. Where one grade change advances
+several leaves at once, because a subsection carries several criteria, those leaves are locked in
+primary-key order for the same reason. This is an ordinary single-row lock.
 
 **3. Entry point: edx-platform subsection grade change.** edx-platform
-computes subsection grades in an async celery task (`recalculate_subsection_grade_v3`) triggered by a score-change signal, not on the
+computes subsection grades in an async celery task (``recalculate_subsection_grade_v3``) triggered by a score-change signal, not on the
 request thread. After that task writes the subsection grade, it calls a public openedx-core function
 within the same transaction; this function does the monotone merge and the upward roll-up. This should be generalized as needed to other places that trigger a competency status update.
 

--- a/docs/openedx_learning/decisions/0005-competency-mastery-storage.rst
+++ b/docs/openedx_learning/decisions/0005-competency-mastery-storage.rst
@@ -1,0 +1,233 @@
+.. _openedx-learning-adr-0005:
+
+5. How should learner competency status be stored at scale?
+===========================================================
+
+Status
+------
+Proposed.
+
+Context
+-------
+Competency achievement criteria form a boolean tree (:ref:`openedx-learning-adr-0002`). A
+``CompetencyCriterion`` leaf points at one tag/object association and a rule; a
+``CompetencyCriteriaGroup`` combines its children with an ``AND``/``OR`` operator, up to the
+competency itself. A learner's mastery is tracked against that tree in three tables, one per level:
+``StudentCompetencyCriteriaStatus`` (leaf), ``StudentCompetencyCriteriaGroupStatus`` (group), and
+``StudentCompetencyStatus`` (competency). :ref:`openedx-learning-adr-0002`, Decision 6 defines their
+columns and :ref:`openedx-learning-adr-0003`, Decision 5 says they are updated in place.
+
+Row count concentrates at the leaf. A course can carry on the order of 200 leaf criteria, so the
+leaf table holds roughly learners x attempted leaves, which reaches the low billions for an Open edX
+instance with millions of learners. The two tables above it are smaller, by the tree's fan-out.
+
+That scale is not, on its own, what makes a relational database struggle. A point lookup against a
+billion-row table backed by the right composite index is a logarithmic-time index seek regardless of
+the table's size, and every read this ADR sizes for is such a lookup: the learner-facing dashboard
+asks for one learner's status, and each index in :ref:`openedx-learning-adr-0002`, Decision 5 leads
+with the learner. What billions of rows makes painful is schema migrations, backups, and any
+non-indexed or aggregate query.
+
+So the question here is narrow: given that row count, does the leaf level need storage treatment of
+its own, or does it use the same database and the same conventions as everything else in this repo?
+
+Decision
+--------
+
+1. **Materialize a status row at all three levels, including the leaf.** Each table holds at most one
+   row per learner and node, updated in place, and that row is the learner's current status. A row
+   exists only once the learner has attempted that node, so absence means not yet attempted rather
+   than a status of its own. Nothing is recomputed on read, so a read is a direct indexed lookup on
+   the unique ``(learner, node)`` index (:ref:`openedx-learning-adr-0002`, Decision 5) rather than an
+   evaluation of the tree. Storing the leaf in particular freezes what a learner demonstrated against
+   the criteria as they stood at the time, so later restructuring of the tree cannot change it.
+
+2. **A status write is an upsert against that unique index**, not a read-then-insert. Two workers
+   handling a redelivered grade event can both find no row for a learner and node and both try to
+   insert one; the unique index has to resolve that race rather than fail it, since surviving
+   duplicate delivery is what :ref:`openedx-learning-adr-0004`, Decision 2 is for, and its Decision 3
+   lock is on the group row, which does not protect a leaf row that does not exist yet.
+
+3. **All three tables live in the deployment's default database, unpartitioned and unsharded, and
+   are both read and written on the primary.** One recording therefore runs on one connection. That
+   is what lets :ref:`openedx-learning-adr-0004`, Decision 1 commit the leaf write, every ancestor
+   write, and the platform's grade write as a single transaction, and what makes the group row lock
+   in :ref:`openedx-learning-adr-0004`, Decision 3 actually serialize the writers it is aimed at.
+
+4. **These tables get no schema conventions of their own.** They take this repo's defaults: a
+   ``BigAutoField`` primary key (:ref:`openedx-content-adr-0003`, and OEP-68 for Open edX models
+   generally) and a real foreign key to ``settings.AUTH_USER_MODEL``. Their size is not by itself a
+   reason to deviate.
+
+Assumptions
+-----------
+
+1. The consuming deployment routes these tables and the platform's grade write to the same database
+   alias. ``transaction.atomic()`` is per-alias, so a router that splits them silently voids
+   :ref:`openedx-learning-adr-0004`, Decision 1 with no error and no failing test. This holds in
+   edx-platform today, but it is a property of a repo this one cannot see or enforce.
+
+2. No caller redirects the recorder's reads to a read replica. edx-platform installs
+   ``edx_django_utils``'s ``ReadReplicaRouter``, which defaults reads to the writer but exposes a
+   thread-local ``read_queries_only()`` that redirects reads for every model inside the block. The
+   recorder reads the value it is about to overwrite and takes ``SELECT ... FOR UPDATE`` on a group
+   row; neither survives being routed to a replica.
+
+Out of Scope
+------------
+
+**Learner status history is left to a future ADR.** An audit trail is a real requirement: an
+instance needs to be able to explain why a learner did or did not achieve mastery of a competency,
+or of any of the associated measurement instruments such as a gradeable subsection. The three tables
+decided here do not provide it, because an in-place update overwrites the status it replaces.
+
+What this decision alone can answer:
+
+- A learner's current status at any level, as a point lookup.
+- Which criterion, and through it which tag/object association, currently backs a leaf status. The
+  criterion foreign key survives, and those associations cannot be hard-deleted once learner status
+  exists (:ref:`openedx-learning-adr-0003`, Decision 3).
+- What rule a criterion carried at some past time, from the ``django-simple-history`` records on the
+  definition models (:ref:`openedx-learning-adr-0003`, Decision 1).
+- When a status last changed, from ``modified`` (:ref:`openedx-learning-adr-0002`, Decision 6).
+
+What it cannot answer: a learner's status as of an arbitrary past date, the path a node took through
+the status lattice, why a status was kept rather than lowered after a downward grade correction, or
+what a tag/object association looked like when it produced a status, since ``oel_tagging_objecttag``
+carries no history of its own and edits to it remain permitted
+(:ref:`openedx-learning-adr-0003`, Decision 4).
+
+One constraint carries forward to whatever decides history: it may add tables, but it may not make
+these three append-only. The unique ``(learner, node)`` indexes in
+:ref:`openedx-learning-adr-0002`, Decision 5 already forbid it, and
+:ref:`openedx-learning-adr-0004`, Decisions 2 and 3 need exactly one row per learner and node to
+merge into and to lock.
+
+A signal-based history mechanism such as ``django-simple-history`` records nothing written through
+``queryset.update()`` or ``bulk_update()``. That is a constraint on the recorder now, not on the
+future ADR: it is built first, and if it writes in bulk it forecloses that option before anyone
+reads this.
+
+Deferring history is cheap rather than free: adding a table later is an additive migration that
+touches none of the columns or indexes decided here, and automatic updates advance a status a
+bounded number of times per learner and node, since the lattice is small and
+:ref:`openedx-learning-adr-0004`, Decision 2 never lowers one. Staff edits
+(:ref:`openedx-learning-adr-0004`, Decision 4) can lower a status and so allow it to advance again,
+but they are human-initiated and rare enough not to change the order of magnitude. What cannot be
+recovered is the record of what happened before that table exists.
+
+Two further questions are not settled here: what happens to these rows when a user is deleted or
+retired, and how staff-facing reads that span learners rather than a single learner are served.
+Every index decided so far leads with the learner, so a cross-learner or aggregate read is exactly
+the non-indexed query this ADR's Context calls painful at this row count.
+
+Rejected Alternatives
+---------------------
+
+1. Compute leaves transiently, never store them.
+
+    - Pros:
+        - Eliminates the largest table, since leaf demonstration would be computed on demand from
+          the leaf's rule and the learner's grade.
+    - Cons:
+        - A recomputed leaf reflects the rule as it stands now, not the rule that was in force when
+          the learner was graded. That contradicts :ref:`openedx-learning-adr-0003`, Decision 4,
+          which says criteria edits apply going forward and do not retroactively update existing
+          learner statuses, and it can silently lower a status, which its Decision 5 forbids.
+
+2. Keep the tables append-only: never update a row, and resolve current status as the latest row for
+   a learner and node.
+
+    - Pros:
+        - Every write is an insert rather than a read-modify-write, so there is no current row to
+          keep consistent.
+    - Cons:
+        - A read must resolve the latest row for a learner and node rather than reading one in-place
+          row, which is more expensive and more complex.
+        - There is no single current row for :ref:`openedx-learning-adr-0004`, Decision 3 to lock,
+          and nothing for its Decision 2 merge to write into. Both would have to be redesigned.
+        - This was the design before :ref:`openedx-learning-adr-0003`, Decision 5, and reopening it
+          here would settle the deferred history question by accident and only partly, since a status
+          row records neither who changed it nor why.
+
+3. Put the leaf table behind its own Django database alias and router, or make a separate physical
+   database mandatory, or partition or shard it, up front.
+
+    - Pros:
+        - Physically isolates or splits the largest table from the start. In the router variant the
+          alias would default to the main database, letting a deployment opt into a separate
+          physical database later without a schema change.
+        - There is prior art in edx-platform, the courseware-history router
+          (``StudentModuleHistoryExtended``).
+    - Cons:
+        - A second alias gives up atomicity, and here that is disqualifying rather than merely
+          costly. Django runs a write to another alias on its own connection, so the leaf write and
+          the ancestor writes could no longer share one transaction with the grade write, which is
+          what :ref:`openedx-learning-adr-0004`, Decision 1 requires.
+        - The prior art does not actually support the pattern: edx-platform's courseware-history
+          router was retrofitted to work around a 32-bit primary key running out, not adopted as a
+          scaling design.
+        - Mandating a separate physical database or a partitioning scheme imposes real operational
+          cost on every deployment, with nothing measured to justify it.
+        - Premature, and mostly reversible: an alias, a separate physical database, and
+          application-level sharding all remain available if a specific need is proven. Native MySQL
+          partitioning does not, and that is accepted here: MySQL requires every column of the
+          partitioning expression to appear in every unique key, and Decision 4's surrogate ``id``
+          primary key and Decision 1's unique ``(learner, node)`` key share no column, so partitioning
+          would first mean changing the primary key of the largest table in the schema.
+
+4. Store child evaluations on the parent group row instead of a leaf table (an enriched
+   attained-set).
+
+    - Pros:
+        - Avoids the largest table entirely.
+    - Cons:
+        - A leaf write stops being an independent single-row merge and becomes a read-modify-write
+          of a column shared with every sibling, so it has to hold the group lock across the whole
+          write rather than only across the recompute
+          (:ref:`openedx-learning-adr-0004`, Decisions 2 and 3).
+        - Reaches past this ADR: it would also mean amending :ref:`openedx-learning-adr-0002`,
+          Decisions 5 and 7 and :ref:`openedx-learning-adr-0003`, Decision 4, all of which key on a
+          per-leaf status row existing.
+        - A status packed into a per-group array has no unique index and no foreign key behind it,
+          so nothing but application code keeps it consistent with the criteria it describes.
+        - Couples a leaf's frozen mastery to the current shape of the criteria tree, so restructuring
+          the tree can corrupt already-recorded mastery (Decision 1).
+        - The single-row group read it optimizes is already served acceptably by an indexed range
+          read of a learner's leaf rows.
+
+5. Serve heavy reads of the leaf table from a read replica
+   (``edx_django_utils``'s ``read_replica_or_default()``).
+
+    - Pros:
+        - Keeps dashboard and reporting reads of the largest table off the primary, where row count
+          and read volume concentrate.
+    - Cons:
+        - Premature: no measurement shows the primary struggling with these reads. The dashboard
+          reads are point lookups on a composite index, not the large, expensive, widely-called
+          reads that drive ``StudentModule`` load in edx-platform, so CBE read load should be much
+          lower.
+        - Replica lag is a correctness hazard next to the recorder, which must read the primary. A
+          replica cannot serve the ``SELECT ... FOR UPDATE`` in :ref:`openedx-learning-adr-0004`,
+          Decision 3 at all. Introducing replica reads means maintaining that distinction in every
+          new read path.
+        - Adding it later is cheap, since it is a per-query choice rather than a schema decision.
+
+6. Give the leaf table a custom unsigned 64-bit primary key (``UnsignedBigIntAutoField``), as
+   edx-platform does on ``PersistentSubsectionGrade``.
+
+    This doubles the positive range of a plain ``BigAutoField``, but that range is already far out of
+    reach for this table, and an instance approaching it would hit other limits first. A custom field
+    type carries ongoing maintenance cost, and unsigned integers do not exist in PostgreSQL.
+    ``BigAutoField`` is the default for Open edX models, so these tables need no primary-key decision
+    of their own.
+
+7. Drop the database-level constraint on the learner foreign key (``db_constraint=False``), mirroring
+   edx-platform's ``StudentModule``.
+
+    The argument for it was that a real constraint costs write throughput at this volume, because a
+    hot user row would see extra lock contention. Reports of user-row contention in edx-platform do
+    exist (which is why ``completion`` and ``bookmarks`` dropped their constraints), but they are not
+    understood well enough to design around here. This repo's convention is a real foreign key to
+    ``settings.AUTH_USER_MODEL``, which already keeps the models independent of any concrete user
+    model, so these tables follow it and need no decision of their own.

--- a/docs/openedx_learning/decisions/0005-competency-mastery-storage.rst
+++ b/docs/openedx_learning/decisions/0005-competency-mastery-storage.rst
@@ -17,9 +17,14 @@ competency itself. A learner's mastery is tracked against that tree in three tab
 ``StudentCompetencyStatus`` (competency). :ref:`openedx-learning-adr-0002`, Decision 6 defines their
 columns and :ref:`openedx-learning-adr-0003`, Decision 5 says they are updated in place.
 
-Row count concentrates at the leaf. A course can carry on the order of 200 leaf criteria, so the
+Row count concentrates at the leaf. A course may for example carry on the order of 200 leaf criteria, so the
 leaf table holds roughly learners x attempted leaves, which reaches the low billions for an Open edX
 instance with millions of learners. The two tables above it are smaller, by the tree's fan-out.
+
+If we store history of status attempts, or if we use append-only tables, we add a multiplier:
+learners x attempted leaves x problem attempts for this leaf and learner. That means that every time
+a problem in a subsection is attempted by a student, a new row is written. That would increase the order
+of magnitude well beyond the potential low billions to easily tens of billions.
 
 That scale is not, on its own, what makes a relational database struggle. A point lookup against a
 billion-row table backed by the right composite index is a logarithmic-time index seek regardless of
@@ -28,101 +33,37 @@ asks for one learner's status, and each index in :ref:`openedx-learning-adr-0002
 with the learner. What billions of rows makes painful is schema migrations, backups, and any
 non-indexed or aggregate query.
 
-So the question here is narrow: given that row count, does the leaf level need storage treatment of
-its own, or does it use the same database and the same conventions as everything else in this repo?
+On the requirements side, no student competency status history is needed. This allows us to
+define the tables without history or append-only restraints.
 
 Decision
 --------
 
-1. **Materialize a status row at all three levels, including the leaf.** Each table holds at most one
-   row per learner and node, updated in place, and that row is the learner's current status. A row
-   exists only once the learner has attempted that node, so absence means not yet attempted rather
-   than a status of its own. Nothing is recomputed on read, so a read is a direct indexed lookup on
-   the unique ``(learner, node)`` index (:ref:`openedx-learning-adr-0002`, Decision 5) rather than an
-   evaluation of the tree. Storing the leaf in particular freezes what a learner demonstrated against
-   the criteria as they stood at the time, so later restructuring of the tree cannot change it.
+1. **Do not store history for student competency statuses. Don't add a history table.**
+   Because the history that is needed for Competencies is owned by ORAs, there is
+   no need to store history of competency status changes.
+   And storing history on a massive leaf table is difficult because:
+   - The history table grows with each problem attempt without clear bounds.
+   - Similar huge tables in openedx-platform pose a big maintenance burden.
+   - Truncation and deletion poses challenges.
+   - Storage is expensive.
 
-2. **A status write is an upsert against that unique index**, not a read-then-insert. Two workers
-   handling a redelivered grade event can both find no row for a learner and node and both try to
-   insert one; the unique index has to resolve that race rather than fail it, since surviving
-   duplicate delivery is what :ref:`openedx-learning-adr-0004`, Decision 2 is for, and its Decision 3
-   lock is on the group row, which does not protect a leaf row that does not exist yet.
+2. **Update Rows instead of making them append-only.**
+   Having append-only tables for competency statuses runs into the same problem. They will
+   grow just as massive. Instead, since we don't need to track history,
+   it is sufficient to just update a row when it changes. This scales much better.
 
-3. **All three tables live in the deployment's default database, unpartitioned and unsharded, and
-   are both read and written on the primary.** One recording therefore runs on one connection. That
-   is what lets :ref:`openedx-learning-adr-0004`, Decision 1 commit the leaf write, every ancestor
-   write, and the platform's grade write as a single transaction, and what makes the group row lock
-   in :ref:`openedx-learning-adr-0004`, Decision 3 actually serialize the writers it is aimed at.
-
-4. **These tables get no schema conventions of their own.** They take this repo's defaults: a
-   ``BigAutoField`` primary key (:ref:`openedx-content-adr-0003`, and OEP-68 for Open edX models
-   generally) and a real foreign key to ``settings.AUTH_USER_MODEL``. Their size is not by itself a
-   reason to deviate.
-
-Assumptions
------------
-
-1. The consuming deployment routes these tables and the platform's grade write to the same database
-   alias. ``transaction.atomic()`` is per-alias, so a router that splits them silently voids
-   :ref:`openedx-learning-adr-0004`, Decision 1 with no error and no failing test. This holds in
-   edx-platform today, but it is a property of a repo this one cannot see or enforce.
-
-2. No caller redirects the recorder's reads to a read replica. edx-platform installs
-   ``edx_django_utils``'s ``ReadReplicaRouter``, which defaults reads to the writer but exposes a
-   thread-local ``read_queries_only()`` that redirects reads for every model inside the block. The
-   recorder reads the value it is about to overwrite and takes ``SELECT ... FOR UPDATE`` on a group
-   row; neither survives being routed to a replica.
-
-Out of Scope
-------------
-
-**Learner status history is left to a future ADR.** An audit trail is a real requirement: an
-instance needs to be able to explain why a learner did or did not achieve mastery of a competency,
-or of any of the associated measurement instruments such as a gradeable subsection. The three tables
-decided here do not provide it, because an in-place update overwrites the status it replaces.
-
-What this decision alone can answer:
-
-- A learner's current status at any level, as a point lookup.
-- Which criterion, and through it which tag/object association, currently backs a leaf status. The
-  criterion foreign key survives, and those associations cannot be hard-deleted once learner status
-  exists (:ref:`openedx-learning-adr-0003`, Decision 3).
-- What rule a criterion carried at some past time, from the ``django-simple-history`` records on the
-  definition models (:ref:`openedx-learning-adr-0003`, Decision 1).
-- When a status last changed, from ``modified`` (:ref:`openedx-learning-adr-0002`, Decision 6).
-
-What it cannot answer: a learner's status as of an arbitrary past date, the path a node took through
-the status lattice, why a status was kept rather than lowered after a downward grade correction, or
-what a tag/object association looked like when it produced a status, since ``oel_tagging_objecttag``
-carries no history of its own and edits to it remain permitted
-(:ref:`openedx-learning-adr-0003`, Decision 4).
-
-One constraint carries forward to whatever decides history: it may add tables, but it may not make
-these three append-only. The unique ``(learner, node)`` indexes in
-:ref:`openedx-learning-adr-0002`, Decision 5 already forbid it, and
-:ref:`openedx-learning-adr-0004`, Decisions 2 and 3 need exactly one row per learner and node to
-merge into and to lock.
-
-A signal-based history mechanism such as ``django-simple-history`` records nothing written through
-``queryset.update()`` or ``bulk_update()``. That is a constraint on the recorder now, not on the
-future ADR: it is built first, and if it writes in bulk it forecloses that option before anyone
-reads this.
-
-Deferring history is cheap rather than free: adding a table later is an additive migration that
-touches none of the columns or indexes decided here, and automatic updates advance a status a
-bounded number of times per learner and node, since the lattice is small and
-:ref:`openedx-learning-adr-0004`, Decision 2 never lowers one. Staff edits
-(:ref:`openedx-learning-adr-0004`, Decision 4) can lower a status and so allow it to advance again,
-but they are human-initiated and rare enough not to change the order of magnitude. What cannot be
-recovered is the record of what happened before that table exists.
-
-Two further questions are not settled here: what happens to these rows when a user is deleted or
-retired, and how staff-facing reads that span learners rather than a single learner are served.
-Every index decided so far leads with the learner, so a cross-learner or aggregate read is exactly
-the non-indexed query this ADR's Context calls painful at this row count.
+3. **Build the student competency status tables for scale.**
+   As some of these tables will become massive, we want to avoid making migrations and schema changes necessary later.
+   Thus, we do our best to make sure that the fields and indexes are future-proof, not needing to add fields later on,
+   and select the indexes so that even a table in the billions of rows can be sufficiently performant.
 
 Rejected Alternatives
 ---------------------
+
+0. Add separate history tables that track status attempts.
+
+   This is not required any longer.
 
 1. Compute leaves transiently, never store them.
 


### PR DESCRIPTION
Draft. Replaces the ADR 0005 in #657, which decided storage and history together.

**Stacked on #713** (ADR 0004), so the diff here is only what ADR 0005 adds. Retarget to `main` once #713 merges.

## What changed

The whole history and audit-trail question moves out to a future ADR. What is left is the MVP storage decision:

1. Materialize a status row at all three levels including the leaf: at most one row per learner and node, updated in place, absent until attempted.
2. That write is an upsert against the unique index, since two workers handling a redelivered event can both find no row and both insert.
3. All three tables in the default database, unpartitioned, read and written on the primary. This is what makes ADR 0004's single transaction and group row lock work.
4. No schema conventions of their own: `BigAutoField` primary key, real FK to `settings.AUTH_USER_MODEL`.

Plus an `Assumptions` section (the deployment routes the grade write to the same alias; nothing redirects the recorder's reads to a replica) and an `Out of Scope` section that records the audit requirement, what the MVP can and cannot answer, and the constraints the future history ADR inherits.

All seven rejected alternatives survive, reworked. Several of their cons cited the HISTORY table and had to be re-derived; most came back stronger against ADR 0004 than they were against history.

## Changes to ADRs 0002 and 0003

Two of these are forward-compatibility, deliberately taken now because both are free today and a migration on a billion-row table later:

* **`CompetencyMasteryStatuses.rank`.** The seeded statuses are listed highest-first and there is no ordering column, so ADR 0004 Decision 2's "store the higher of the two" cannot be a single `UPDATE`. Doing it in Python would need a leaf row lock that ADR 0004's rejected alternative 1 explicitly claims the design does not need.
* **`modified` on the three learner status tables**, with `created` narrowed to the row's first write. Under in-place updates `created` no longer dates the current status. Without this, no MVP-era row can be dated, which makes a later history table's backfill meaningless.
* `CompetencyRuleProfile.archived` said archived profiles keep learner status *history* resolvable. It keeps *rows* resolvable.
* ADR 0003's Context sized learner data as `learners x criteria x time`. The time factor was append-only residue.
* ADR 0003 Decision 5's "how history is retained is not decided here" now points at where it is deferred to.

ADR 0001 and ADR 0004 need no changes.

## Open questions for review

* **Staff-facing reads have no index.** Every learner status index leads with the learner, so "every learner's status for competency X" is exactly the non-indexed query the ADR's own Context calls painful at this row count. Named in Out of Scope rather than decided.
* **User deletion / retirement.** Decision 4 keeps a real FK to the user model but does not say what happens on delete. Named in Out of Scope.
* **Native MySQL partitioning is foreclosed**, not merely deferred: MySQL needs every partitioning column in every unique key, and the surrogate `id` and the unique `(learner, node)` key share none. Stated and accepted rather than glossed as reversible.

## Verification

`sphinx-build` over `docs/` succeeds with zero warnings. `doc8` is clean except one pre-existing trailing-whitespace error on `main`, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
