### PR TITLE
docs: fix inaccuracies in ADR 0012 (non-nullable tag external_id)

### DIFF
--- a/docs/openedx_tagging/decisions/0012-non-nullable-tag-external-id.rst
+++ b/docs/openedx_tagging/decisions/0012-non-nullable-tag-external-id.rst
@@ -50,15 +50,14 @@ migration.
   rare case where that collides with a different tag's pre-existing, hand-assigned
   ``external_id`` in the same taxonomy, the collision must be resolved deterministically
   without an unbounded retry loop, for example by appending an incrementing numeric
-  counter to the copied value until it's unique. Implementations may also transform the
-  copied value for UI legibility, for example uppercasing it and replacing spaces with
-  underscores, but no particular format or collision-resolution scheme is required by
-  this decision.
-- **New tags going forward.** The REST API and import format keep treating
-  ``external_id`` as optional for the caller, unchanged from today. When a tag is
-  created without one, the same backfill algorithm generates one automatically, rather
-  than rejecting the request. No existing integration that omits ``external_id`` today
-  has to change.
+  counter to the copied value until it's unique. No particular format or
+  collision-resolution scheme is required by this decision.
+- **New tags going forward.** The REST API keeps treating ``external_id`` as optional
+  for the caller, unchanged from today. When a tag is created via the API without one,
+  the same backfill algorithm generates one automatically, rather than rejecting the
+  request. No existing API integration that omits ``external_id`` today has to change.
+  The import format already requires an identifier for every tag, unchanged by this
+  decision, so auto-generation only applies to the API creation path.
 - **Institutions can replace an auto-generated value.** If an institution doesn't want
   the auto-generated ``external_id``, they can change it to their own value through
   ADR 0010's rename pathway.
@@ -106,3 +105,12 @@ Changelog
 2026-07-10:
 
 * Proposed.
+
+2026-08-17:
+
+* Scoped the import-format optionality claim to the REST API only; the import format
+  already requires an identifier per tag row.
+* Struck the "uppercase and replace spaces with underscores" legibility example from
+  the backfill algorithm: it isn't injective, so it can map two distinct tag values
+  onto the same ``external_id``, undermining the collision-free argument this decision
+  relies on.


### PR DESCRIPTION
## Summary

While drafting the implementation ticket that goes with ADR 0012, Claude flagged an inaccuracy and a concern in the decision text. This PR corrects them.

The "New tags going forward" bullet claimed both the REST API and import format keep `external_id` optional for the caller. That's wrong for import: the import format has always required an identifier for every tag row, rejected as empty otherwise, so this decision's auto-generation only applies to the API creation path. The bullet is reworded to reflect that.

The backfill algorithm's example of transforming the copied value "for UI legibility" by uppercasing it and replacing spaces with underscores isn't injective: two distinct, legal tag values in the same taxonomy, for example `Wind Instruments` and `Wind_Instruments`, would both collapse to `WIND_INSTRUMENTS` under that transform, producing exactly the `external_id` collision this decision's collision-free argument is meant to rule out. The example is struck. The decision already states that no particular format or collision-resolution scheme is required, so removing the one unsafe example doesn't change what's actually required.

## Context

- #658 — original PR that added ADR 0012
- ADR 0010 (`openedx_tagging`) — the rename pathway this decision builds on, referenced by the "Institutions can replace an auto-generated value" bullet

## Verification

Rebuilt the docs with Sphinx (`python -m sphinx -b html . _build/html_check -W --keep-going`) after each edit; build succeeds with no warnings on this file.