### PR TITLE
docs: fix readthedocs and accept ADR 4

### DIFF
--- a/docs/openedx_learning/decisions/0004-competency-mastery-concurrency.rst
+++ b/docs/openedx_learning/decisions/0004-competency-mastery-concurrency.rst
@@ -5,7 +5,7 @@
 
 Status
 ------
-Proposed.
+Accepted.
 
 Context
 -------

--- a/docs/openedx_learning/decisions/0004-competency-mastery-concurrency.rst
+++ b/docs/openedx_learning/decisions/0004-competency-mastery-concurrency.rst
@@ -155,11 +155,11 @@ Rejected Alternatives
    with another writer already in flight.
 
     - Pros:
-      - Recovers from the race within the same request, without a separate marker or job.
+        - Recovers from the race within the same request, without a separate marker or job.
     - Cons:
-      - Decision 1 shares a transaction only between the grade and its leaf, and Decision 3 commits each rollup level
-        separately before reading the next. That leaves no single transaction boundary for a read-after-write check to
-        run inside: by the time a re-read would happen, the level below has already committed and could change again
-        before the write completes.
-      - It also only checks for a race at the moment each parent is read. If the worker crashes mid-cascade before reaching the next read,
-        nothing notices the rollup was left unfinished. Decision 5's manual recovery mechanism exists to catch that case.
+        - Decision 1 shares a transaction only between the grade and its leaf, and Decision 3 commits each rollup level
+          separately before reading the next. That leaves no single transaction boundary for a read-after-write check to
+          run inside: by the time a re-read would happen, the level below has already committed and could change again
+          before the write completes.
+        - It also only checks for a race at the moment each parent is read. If the worker crashes mid-cascade before reaching the next read,
+          nothing notices the rollup was left unfinished. Decision 5's manual recovery mechanism exists to catch that case.


### PR DESCRIPTION
- The competency mastery concurrency ADR has been agreed, so its status moves from Proposed to Accepted. No other content changes.
- Fixes the readthedocs build that's broken on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)